### PR TITLE
Improve debugging output of ClassLauncher

### DIFF
--- a/src/main/java/net/imagej/launcher/ClassLauncher.java
+++ b/src/main/java/net/imagej/launcher/ClassLauncher.java
@@ -197,6 +197,7 @@ public class ClassLauncher {
 		if (classLoader == null) {
 			classLoader = Thread.currentThread().getContextClassLoader();
 		}
+		if (debug) System.err.println("Class loader = " + classLoader);
 		final String noSlashes = className.replace('/', '.');
 		try {
 			main = classLoader.loadClass(noSlashes);


### PR DESCRIPTION
Turns on debugging of ClassLauncher when `ij.debug` is set, and adds a few small bits of debugging output in some places, particular when exceptions are being caught.
