### PR TITLE
Default to INFO log level for CLI tools

### DIFF
--- a/src/main/c/ImageJ.c
+++ b/src/main/c/ImageJ.c
@@ -880,7 +880,7 @@ static void add_subcommand(const char *line)
 }
 
 const char *default_subcommands[] = {
-	"--update --dont-patch-ij1 --full-classpath --main-class=net.imagej.updater.CommandLine",
+	"--update --info --dont-patch-ij1 --full-classpath --main-class=net.imagej.updater.CommandLine",
 	" start the command-line version of the ImageJ updater",
 	"--jython --ij-jar=jars/jython.jar --full-classpath --main-class=org.python.util.jython",
 	".py",


### PR DESCRIPTION
Specifically, the updater should default to INFO level logging, as per issue #9.
