### PR TITLE
Fix java.ext.dirs path on OS X

### DIFF
--- a/src/main/c/ImageJ.c
+++ b/src/main/c/ImageJ.c
@@ -1661,6 +1661,7 @@ static void parse_command_line(void)
 	if (ext_option.length)
 		string_add_char(&ext_option, ':');
 	string_append(&ext_option, ij_path("java/macosx-java3d/Home/lib/ext"));
+	string_add_char(&ext_option, ':');
 	string_addf(&ext_option, "/Library/Java/Extensions:"
 		"/System/Library/Java/Extensions:"
 		"/System/Library/Frameworks/JavaVM.framework/Home/lib/ext");


### PR DESCRIPTION
As reported by @cmci [on the ImageJ mailing list](https://list.nih.gov/cgi-bin/wa.exe?A2=IMAGEJ;5de8bddc.1407), the `java.ext.dirs` system property is set to `ImageJ.app/java/macosx-java3d/Home/lib/ext/Library/Java/Extensions` rather than `Fiji.app/java/macosx-java3d/Home/lib/ext` as intended, which causes problems with the local Java3D installation.
