### PR TITLE
Add a fallback to launch the ImageJ updater if net.imagej.Main could not launch

### DIFF
--- a/src/main/java/net/imagej/launcher/ClassLauncher.java
+++ b/src/main/java/net/imagej/launcher/ClassLauncher.java
@@ -189,7 +189,7 @@ public class ClassLauncher {
 			if ("net.imagej.Main".equals(mainClass) &&
 					!containsBatchOption(arguments) &&
 					!GraphicsEnvironment.isHeadless() &&
-					RemoteUpdater.runRemote()) {
+					RemoteUpdater.runRemote(t)) {
 				return;
 			}
 			System.exit(1);

--- a/src/test/java/net/imagej/launcher/RemoteUpdaterTestDrive.java
+++ b/src/test/java/net/imagej/launcher/RemoteUpdaterTestDrive.java
@@ -40,7 +40,7 @@ public class RemoteUpdaterTestDrive {
 
 	public static void main(String[] args) {
 		System.setProperty("imagej.dir", System.getProperty("user.home") + "/Fiji.app");
-		System.err.println(RemoteUpdater.runRemote());
+		System.err.println(RemoteUpdater.runRemote(new Throwable()));
 	}
 
 }


### PR DESCRIPTION
Every once in a while (and more so in the beta phase) things do not quite work well together in the ImageJ startup. Even after the ImageJ components stabilize, with the flexibility of the SciJava service framework, it is possible for third-party components to interfere inadvertently with a successful SciJava context initialization.

In such cases, the user is stuck with a non-functioning setup at the moment.

Let's be nicer and use the fallback procedure established in Fiji (when the updater moved into ImageJ2) to help users get back to a working system: detect when the `main` method could not be called successfully and start the updater remotely, via [`bootstrap.js`](https://github.com/imagej/imagej-updater/blob/master/bin/bootstrap.js).
