### PR TITLE
Avoid requiring Java 1.6 even on modern MacOSX versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -372,8 +372,6 @@ Institute of Molecular Cell Biology and Genetics.</organizationName>
 									<option>CoreFoundation</option>
 									<option>-framework</option>
 									<option>ApplicationServices</option>
-									<option>-framework</option>
-									<option>JavaVM</option>
 								</options>
 							</linker>
 						</configuration>
@@ -422,8 +420,6 @@ Institute of Molecular Cell Biology and Genetics.</organizationName>
 									<option>CoreFoundation</option>
 									<option>-framework</option>
 									<option>ApplicationServices</option>
-									<option>-framework</option>
-									<option>JavaVM</option>
 								</options>
 							</linker>
 						</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -288,7 +288,7 @@ Institute of Molecular Cell Biology and Genetics.</organizationName>
 					<name>Mac OS X</name>
 				</os>
 				<file>
-					<exists>/Library/Java/JavaVirtualMachines/jdk1.7.0_45.jdk/Contents/Home/include/</exists>
+					<exists>/System/Library/Frameworks/JavaVM.framework/Versions/Current/Headers/</exists>
 				</file>
 			</activation>
 			<build>
@@ -303,8 +303,7 @@ Institute of Molecular Cell Biology and Genetics.</organizationName>
 									<option>-DLAUNCHER_VERSION="${project.version}"</option>
 									<option>-DBUILD_NUMBER="${buildNumber}"</option>
 									<option>-DNO_JAVA_FRAMEWORK</option>
-									<option>-I/Library/Java/JavaVirtualMachines/jdk1.7.0_45.jdk/Contents/Home/include/</option>
-									<option>-I/Library/Java/JavaVirtualMachines/jdk1.7.0_45.jdk/Contents/Home/include/darwin/</option>
+									<option>-I/System/Library/Frameworks/JavaVM.framework/Versions/Current/Headers/</option>
 									<option>-mmacosx-version-min=10.6</option>
 									<option>-arch</option>
 									<option>x86_64</option>
@@ -353,7 +352,7 @@ Institute of Molecular Cell Biology and Genetics.</organizationName>
 								<options>
 									<option>-DLAUNCHER_VERSION="${project.version}"</option>
 									<option>-DBUILD_NUMBER="${buildNumber}"</option>
-									<option>-I/System/Library/Frameworks/JavaVM.Framework/Headers</option>
+									<option>-I/System/Library/Frameworks/JavaVM.framework/Versions/Current/Headers/</option>
 									<option>-mmacosx-version-min=10.4</option>
 									<option>-arch</option>
 									<option>i386</option>

--- a/src/main/c/ImageJ.c
+++ b/src/main/c/ImageJ.c
@@ -2359,52 +2359,21 @@ int start_ij(void)
 	return 0;
 }
 
-static void find_newest(struct string *relative_path, int max_depth, const char *file, struct string *result)
-{
-	int len = relative_path->length;
-	DIR *directory;
-	struct dirent *entry;
-
-	string_add_char(relative_path, '/');
-
-	string_append(relative_path, file);
-	if (file_exists(ij_path(relative_path->buffer)) && is_native_library(ij_path(relative_path->buffer))) {
-		string_set_length(relative_path, len);
-		if (!result->length || file_is_newer(ij_path(relative_path->buffer), ij_path(result->buffer)))
-			string_set(result, relative_path->buffer);
-	}
-
-	if (max_depth <= 0)
-		return;
-
-	string_set_length(relative_path, len);
-	directory = opendir(ij_path(relative_path->buffer));
-	if (!directory)
-		return;
-	string_add_char(relative_path, '/');
-	while (NULL != (entry = readdir(directory))) {
-		if (entry->d_name[0] == '.')
-			continue;
-		string_append(relative_path, entry->d_name);
-		if (dir_exists(ij_path(relative_path->buffer)))
-			find_newest(relative_path, max_depth - 1, file, result);
-		string_set_length(relative_path, len + 1);
-	}
-	closedir(directory);
-	string_set_length(relative_path, len);
-}
-
 /* TODO: try to find Java even if there is JRE local to ImageJ */
 static void adjust_java_home_if_necessary(void)
 {
 	struct string *result, *buffer, *path;
 	const char *prefix = "jre/";
-	int depth = 2;
+	int depth = 2, ij_dir_len;
+
+	if (get_library_path())
+		return; /* already set, no need to adjust */
 
 	set_default_library_path();
 	set_library_path(get_default_library_path());
 
-	buffer = string_copy("java");
+	buffer = string_copy(ij_path("java"));
+	ij_dir_len = buffer->length - 4;
 	result = string_init(32);
 	path = string_initf("%s%s", prefix, get_library_path());
 
@@ -2413,12 +2382,12 @@ static void adjust_java_home_if_necessary(void)
 		if (result->buffer[result->length - 1] != '/')
 			string_add_char(result, '/');
 		string_append(result, prefix);
-		set_relative_java_home(xstrdup(result->buffer));
+		set_relative_java_home(xstrdup(result->buffer + ij_dir_len));
 	}
 	else if (*prefix) {
 		find_newest(buffer, depth + 1, get_library_path(), buffer);
 		if (result->length)
-			set_relative_java_home(xstrdup(result->buffer));
+			set_relative_java_home(xstrdup(result->buffer + ij_dir_len));
 	}
 	string_release(buffer);
 	string_release(result);

--- a/src/main/c/ImageJ.c
+++ b/src/main/c/ImageJ.c
@@ -269,14 +269,16 @@ static int create_java_vm(JavaVM **vm, void **env, JavaVMInitArgs *args)
 	 * nothing if not entertaining.
 	 */
 	string_addf(buffer, "%s/%s", java_home, "lib/jli/libjli.dylib");
-	if (debug)
-		error("Work around attempt at MacOSX world domination: %s",
-				buffer->buffer);
-	handle = dlopen(buffer->buffer, RTLD_LAZY);
-	if (!handle) {
-		error("Could not open %s: %s", buffer->buffer, dlerror());
-		string_release(buffer);
-		return 1;
+	if (file_exists(buffer->buffer)) {
+		if (debug)
+			error("Work around attempt at MacOSX world domination: %s",
+					buffer->buffer);
+		handle = dlopen(buffer->buffer, RTLD_LAZY);
+		if (!handle) {
+			error("Could not open %s: %s", buffer->buffer, dlerror());
+			string_release(buffer);
+			return 1;
+		}
 	}
 	string_set_length(buffer, 0);
 #endif

--- a/src/main/c/ImageJ.c
+++ b/src/main/c/ImageJ.c
@@ -219,13 +219,6 @@ static void maybe_reexec_with_correct_lib_path(struct string *java_library_path)
 
 static int create_java_vm(JavaVM **vm, void **env, JavaVMInitArgs *args)
 {
-#if defined(__APPLE__) && !defined(NO_JAVA_FRAMEWORK)
-	if (!set_path_to_apple_JVM()) {
-		/* We found an Apple Framework JVM (pre-Java-1.7). */
-		return JNI_CreateJavaVM(vm, env, args);
-	}
-#endif
-
 	/*
 	 * At this point, we are either not on OS X, or on a
 	 * newer OS X that is missing the Apple Framework paths:
@@ -2413,6 +2406,9 @@ int main(int argc, char **argv, char **e)
 
 #if defined(__APPLE__)
 	launch_32bit_on_tiger(argc, argv);
+#if !defined(NO_JAVA_FRAMEWORK)
+	set_path_to_apple_JVM();
+#endif
 #elif defined(WIN64)
 	/* work around MinGW64 breakage */
 	argc = __argc;

--- a/src/main/c/ImageJ.c
+++ b/src/main/c/ImageJ.c
@@ -313,6 +313,12 @@ static int create_java_vm(JavaVM **vm, void **env, JavaVMInitArgs *args)
 
 	JNI_CreateJavaVM = dlsym(handle, JNI_CREATEVM);
 	err = dlerror();
+#ifdef __APPLE__
+	if (err) {
+		JNI_CreateJavaVM = dlsym(handle, "JNI_CreateJavaVM_Impl");
+		err = dlerror();
+	}
+#endif
 	if (err) {
 		error("Error loading libjvm: %s: %s", buffer->buffer, err);
 		setenv_or_exit("JAVA_HOME", original_java_home_env, 1);

--- a/src/main/c/platform.c
+++ b/src/main/c/platform.c
@@ -397,6 +397,37 @@ int set_path_to_apple_JVM(void)
 		CFBundleGetBundleWithIdentifier(CFSTR("com.apple.JavaVM"));
 
 	if (!JavaVMBundle) {
+		struct string *base = string_copy("/Library/Java/JavaVirtualMachines");
+		struct string *result = string_init(32);
+		const char *library_path;
+
+		library_path = "Contents/Home/jre/lib/server/libjvm.dylib";
+		find_newest(base, 1, library_path, result);
+		if (result->length) {
+			set_library_path(library_path + strlen("Contents/Home/jre/"));
+			string_append(result, "/Contents/Home/");
+			if (debug) error("Discovered modern JRE: '%s'", result->buffer);
+			set_java_home(result->buffer);
+			string_release(base);
+			return 1;
+		}
+
+		string_set_length(base, 0);
+		string_append(base, "/System/Library/Java/JavaVirtualMachines");
+		if (sizeof(void *) > 4)
+			library_path = "Contents/Home/../Libraries/libserver.dylib";
+		else
+			library_path = "Contents/Home/../Libraries/libjvm.dylib";
+		find_newest(base, 1, library_path, result);
+		string_release(base);
+		if (result->length) {
+			set_library_path(library_path + strlen("Contents/Home/"));
+			string_append(result, "/Contents/Home/");
+			if (debug) error("Discovered JavaVM framework: '%s'", result->buffer);
+			set_java_home(result->buffer);
+			return 1;
+		}
+
 		fprintf(stderr, "Warning: could not find Java bundle\n");
 		return 3;
 	}

--- a/src/main/include/file-funcs.h
+++ b/src/main/include/file-funcs.h
@@ -56,4 +56,6 @@ extern void set_ij_dir(const char *path);
 extern void infer_ij_dir(const char *main_argv0);
 extern const char *ij_path(const char *relative_path);
 
+void find_newest(struct string *relative_path, int max_depth, const char *file, struct string *result);
+
 #endif


### PR DESCRIPTION
On modern MacOSX versions (10.8 and newer), newer Java versions are available. However, due to our linking to the JavaVM framework – in which form Java is no longer provided – MacOSX asks the user to download Java 1.6, even if a `--java-home` argument is passed.

Let's switch to the `dlopen()` method instead which avoids downloading Java 1.6, and let's also default to the newest Java that is installed by the user (or administrator).