### PR TITLE
Support bundled Java 8 on OSX

### DIFF
--- a/src/main/c/ImageJ.c
+++ b/src/main/c/ImageJ.c
@@ -79,8 +79,11 @@
 
 static const char *default_fiji1_class = "fiji.Main";
 static const char *default_main_class = "net.imagej.Main";
-int retrotranslator;
-int debug, info;
+
+/* Define global variables declared in common.h */
+int debug = 0;
+int info = 0;
+int retrotranslator = 0;
 
 static const char *legacy_ij1_class = "ij.ImageJ";
 
@@ -1339,8 +1342,9 @@ static int handle_one_option2(int *i, int argc, const char **argv)
 {
 	if (!strcmp(argv[*i], "--dry-run"))
 		options.dry_run++;
-	else if (!strcmp(argv[*i], "--debug"))
+	else if (!strcmp(argv[*i], "--debug")) {
 		debug++;
+	}
 	else if (!strcmp(argv[*i], "--info"))
 		info++;
 	else if (handle_one_option(i, argv, "--java-home", &arg)) {

--- a/src/main/c/ImageJ.c
+++ b/src/main/c/ImageJ.c
@@ -2418,6 +2418,13 @@ int main(int argc, char **argv, char **e)
 {
 	int size;
 
+	/*
+	 * NB: Set the debug mode as early as possible when DEBUG is set.
+	 * Without this, the --debug CLI flag parsing happens too late
+	 * to see debugging output such as JVM detection on OS X.
+	 */
+	if (getenv("DEBUG")) debug++;
+
 	if (!suffixcmp(argv[0], -1, "debug.exe") ||
 			!suffixcmp(argv[0], -1, "debug")) {
 		debug++;

--- a/src/main/c/config.c
+++ b/src/main/c/config.c
@@ -36,7 +36,6 @@
 
 #include <string.h>
 
-extern int debug;
 int legacy_mode;
 struct string *legacy_ij1_options;
 

--- a/src/main/c/file-funcs.c
+++ b/src/main/c/file-funcs.c
@@ -38,8 +38,6 @@
 
 #include <sys/stat.h>
 
-extern int debug;
-
 int find_file(struct string *search_root, int max_depth, const char *file, struct string *result)
 {
 	int len = search_root->length;

--- a/src/main/c/file-funcs.c
+++ b/src/main/c/file-funcs.c
@@ -495,14 +495,35 @@ void find_newest(struct string *path, int max_depth, const char *file, struct st
 	DIR *directory;
 	struct dirent *entry;
 
+	if (debug) error("find_newest: searching '%s' for '%s'", path->buffer, file);
+
 	if (!len || path->buffer[len - 1] != '/')
 		string_add_char(path, '/');
 
 	string_append(path, file);
-	if (file_exists(path->buffer) && is_native_library(path->buffer)) {
-		string_set_length(path, len);
-		if (!result->length || file_is_newer(path->buffer, result->buffer))
-			string_set(result, path->buffer);
+	if (file_exists(path->buffer)) {
+		if (is_native_library(path->buffer)) {
+			string_set_length(path, len);
+			if (!result->length) {
+				if (debug) error("find_newest: found a candidate: '%s'", path->buffer);
+				string_set(result, path->buffer);
+			}
+			else if (file_is_newer(path->buffer, result->buffer)) {
+				if (debug) {
+					error("find_newest: found newer candidate: '%s'", path->buffer);
+				}
+				string_set(result, path->buffer);
+			}
+			else if (debug) {
+				error("find_newest: rejected older candidate: '%s'", path->buffer);
+			}
+		}
+		else if (debug) {
+			error("find_newest: not a native library: '%s'", path->buffer);
+		}
+	}
+	else if (debug) {
+		error("find_newest: file not found: '%s'", path->buffer);
 	}
 
 	if (max_depth <= 0)

--- a/src/main/c/java.c
+++ b/src/main/c/java.c
@@ -43,7 +43,6 @@ static const char *relative_java_home;
 static const char *library_path;
 static const char *default_library_path;
 static struct string *legacy_jre_path;
-extern int debug;
 
 const char *get_java_command(void)
 {

--- a/src/main/c/platform.c
+++ b/src/main/c/platform.c
@@ -430,27 +430,17 @@ int set_path_to_apple_JVM(void)
 		if (debug) error("[APPLE] Found com.apple.JavaVM bundle");
 	}
 	else {
-	const char *java_path = ij_path("java/macosx");
-	struct string *base = string_copy(java_path);
+	struct string *base = string_init(32);
 	struct string *result = string_init(32);
 	const char *library_path;
 
 	if (debug) error("[APPLE] No com.apple.JavaVM bundle found");
 
 	/*
-	 * Look for a local Java shipped with ImageJ
-	 *
-	 * NB: This seems redundant with the adjust_java_home_if_necessary
-	 * logic in ImageJ.c. The problem is a lack of encapsulation,
-	 * causing the adjust_java_home_if_necessary to come too late
-	 * if an OS X Java is discovered.
-	 *
-	 * It would be ideal to detangle this logic to check:
-	 * 1) local java
-	 * 2) java home
-	 * 3) apple java
-	 * 4) anything else
+	 * Look for a local Java shipped with ImageJ in ${ij.dir}/java/macosx
 	 */
+	string_set_length(base, 0);
+	string_append(base, ij_path("java/macosx"));
 	library_path = "jre/Contents/Home/lib/server/libjvm.dylib";
 	find_newest(base, 1, library_path, result);
 	if (result->length) {

--- a/src/main/c/platform.c
+++ b/src/main/c/platform.c
@@ -422,19 +422,9 @@ int set_path_to_apple_JVM(void)
 		return 2;
 	}
 
-	/* Look for the JavaVM bundle using its identifier. */
-	CFBundleRef JavaVMBundle =
-		CFBundleGetBundleWithIdentifier(CFSTR("com.apple.JavaVM"));
-
-	if (JavaVMBundle) {
-		if (debug) error("[APPLE] Found com.apple.JavaVM bundle");
-	}
-	else {
 	struct string *base = string_init(32);
 	struct string *jvm = string_init(32);
 	const char *library_path;
-
-	if (debug) error("[APPLE] No com.apple.JavaVM bundle found");
 
 	/*
 	 * Look for a local Java shipped with ImageJ in ${ij.dir}/java/macosx
@@ -497,8 +487,24 @@ int set_path_to_apple_JVM(void)
 	}
 
 	string_release(base);
-	fprintf(stderr, "Warning: could not find Java bundle\n");
-	return 3;
+
+	/*
+	 * Couldn't find a JDK or JRE or anywhere.
+	 *
+	 * So let's fall back to Apple's API, looking
+	 * for the JavaVM bundle using its identifier.
+	 */
+	if (debug) error("[APPLE] Looking for a JavaVM bundle");
+	CFBundleRef JavaVMBundle =
+		CFBundleGetBundleWithIdentifier(CFSTR("com.apple.JavaVM"));
+	if (JavaVMBundle) {
+		if (debug) error("[APPLE] Found com.apple.JavaVM bundle");
+	}
+	else {
+		/* All searches failed, and no JavaVMBundle. Give up. */
+		if (debug) error("[APPLE] No com.apple.JavaVM bundle found");
+		fprintf(stderr, "Warning: could not find Java bundle\n");
+		return 3;
 	}
 
 	/* Get a path for the JavaVM bundle. */

--- a/src/main/c/platform.c
+++ b/src/main/c/platform.c
@@ -512,6 +512,7 @@ int set_path_to_apple_JVM(void)
 
 	/* Clean up. */
 	string_release(base);
+	string_release(jvm);
 
 	/*
 	 * Couldn't find a JDK or JRE or anywhere.

--- a/src/main/c/platform.c
+++ b/src/main/c/platform.c
@@ -435,10 +435,10 @@ int set_path_to_apple_JVM(void)
 		/*
 		 * Look for a local Java shipped with ImageJ
 		 *
-		 * NB: this seems redundant with the adjust_java_home_if_necessary
-		 * logic in ImageJ.c. The problem is a lack of encapsulation -
-		 * causing the adjust_java_home_if_necessary comes too late if an
-		 * OSX Java is discovered.
+		 * NB: This seems redundant with the adjust_java_home_if_necessary
+		 * logic in ImageJ.c. The problem is a lack of encapsulation,
+		 * causing the adjust_java_home_if_necessary to come too late
+		 * if an OS X Java is discovered.
 		 *
 		 * It would be ideal to detangle this logic to check:
 		 * 1) local java

--- a/src/main/c/platform.c
+++ b/src/main/c/platform.c
@@ -41,9 +41,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-extern int debug;
-extern int retrotranslator;
-
 /* A wrapper for setenv that exits on error */
 void setenv_or_exit(const char *name, const char *value, int overwrite)
 {
@@ -708,8 +705,6 @@ int get_fiji_bundle_variable(const char *key, struct string *value)
 
 static void dummy_call_back(void *info) {
 }
-
-extern int start_ij(void);
 
 static void *start_ij_aux(void *dummy)
 {

--- a/src/main/c/platform.c
+++ b/src/main/c/platform.c
@@ -430,85 +430,85 @@ int set_path_to_apple_JVM(void)
 		if (debug) error("[APPLE] Found com.apple.JavaVM bundle");
 	}
 	else {
-		const char *java_path = ij_path("java/macosx");
-		struct string *base = string_copy(java_path);
-		struct string *result = string_init(32);
-		const char *library_path;
+	const char *java_path = ij_path("java/macosx");
+	struct string *base = string_copy(java_path);
+	struct string *result = string_init(32);
+	const char *library_path;
 
-		if (debug) error("[APPLE] No com.apple.JavaVM bundle found");
+	if (debug) error("[APPLE] No com.apple.JavaVM bundle found");
 
-		/*
-		 * Look for a local Java shipped with ImageJ
-		 *
-		 * NB: This seems redundant with the adjust_java_home_if_necessary
-		 * logic in ImageJ.c. The problem is a lack of encapsulation,
-		 * causing the adjust_java_home_if_necessary to come too late
-		 * if an OS X Java is discovered.
-		 *
-		 * It would be ideal to detangle this logic to check:
-		 * 1) local java
-		 * 2) java home
-		 * 3) apple java
-		 * 4) anything else
-		 */
-		library_path = "jre/Contents/Home/lib/server/libjvm.dylib";
-		find_newest(base, 1, library_path, result);
-		if (result->length) {
-			set_library_path(library_path + strlen("jre/Contents/Home/"));
-			string_append(result, "/jre/Contents/Home/");
-			if (debug) error("[APPLE] Discovered bundled JRE: '%s'", result->buffer);
-			set_java_home(result->buffer);
-			string_release(base);
-			return 1;
-		}
-
-		string_set_length(base, 0);
-		string_append(base, "/Library/Java/JavaVirtualMachines");
-		library_path = "Contents/Home/jre/lib/server/libjvm.dylib";
-		find_newest(base, 1, library_path, result);
-		if (result->length) {
-			set_library_path(library_path + strlen("Contents/Home/jre/"));
-			string_append(result, "/Contents/Home/");
-			if (debug) error("[APPLE] Discovered modern JDK: '%s'", result->buffer);
-			set_java_home(result->buffer);
-			string_release(base);
-			return 1;
-		}
-
-		string_set_length(base, 0);
-		string_append(base, "/Library/Internet Plug-Ins/JavaAppletPlugin.plugin");
-		library_path = "Contents/Home/lib/server/libjvm.dylib";
-		find_newest(base, 1, library_path, result);
-		if (result->length) {
-			set_library_path(library_path + strlen("Contents/Home/"));
-			string_append(result, "/Contents/Home/");
-			if (debug) error("[APPLE] Discovered modern JRE: '%s'", result->buffer);
-			set_java_home(result->buffer);
-			string_release(base);
-			return 1;
-		}
-
-		string_set_length(base, 0);
-		string_append(base, "/System/Library/Java/JavaVirtualMachines");
-		if (sizeof(void *) > 4)
-			library_path = "Contents/Home/../Libraries/libserver.dylib";
-		else
-			library_path = "Contents/Home/../Libraries/libjvm.dylib";
-		find_newest(base, 1, library_path, result);
-		if (result->length) {
-			set_library_path(library_path + strlen("Contents/Home/"));
-			string_append(result, "/Contents/Home/");
-			if (debug) {
-				error("[APPLE] Discovered JavaVM framework: '%s'", result->buffer);
-			}
-			set_java_home(result->buffer);
-			string_release(base);
-			return 1;
-		}
-
+	/*
+	 * Look for a local Java shipped with ImageJ
+	 *
+	 * NB: This seems redundant with the adjust_java_home_if_necessary
+	 * logic in ImageJ.c. The problem is a lack of encapsulation,
+	 * causing the adjust_java_home_if_necessary to come too late
+	 * if an OS X Java is discovered.
+	 *
+	 * It would be ideal to detangle this logic to check:
+	 * 1) local java
+	 * 2) java home
+	 * 3) apple java
+	 * 4) anything else
+	 */
+	library_path = "jre/Contents/Home/lib/server/libjvm.dylib";
+	find_newest(base, 1, library_path, result);
+	if (result->length) {
+		set_library_path(library_path + strlen("jre/Contents/Home/"));
+		string_append(result, "/jre/Contents/Home/");
+		if (debug) error("[APPLE] Discovered bundled JRE: '%s'", result->buffer);
+		set_java_home(result->buffer);
 		string_release(base);
-		fprintf(stderr, "Warning: could not find Java bundle\n");
-		return 3;
+		return 1;
+	}
+
+	string_set_length(base, 0);
+	string_append(base, "/Library/Java/JavaVirtualMachines");
+	library_path = "Contents/Home/jre/lib/server/libjvm.dylib";
+	find_newest(base, 1, library_path, result);
+	if (result->length) {
+		set_library_path(library_path + strlen("Contents/Home/jre/"));
+		string_append(result, "/Contents/Home/");
+		if (debug) error("[APPLE] Discovered modern JDK: '%s'", result->buffer);
+		set_java_home(result->buffer);
+		string_release(base);
+		return 1;
+	}
+
+	string_set_length(base, 0);
+	string_append(base, "/Library/Internet Plug-Ins/JavaAppletPlugin.plugin");
+	library_path = "Contents/Home/lib/server/libjvm.dylib";
+	find_newest(base, 1, library_path, result);
+	if (result->length) {
+		set_library_path(library_path + strlen("Contents/Home/"));
+		string_append(result, "/Contents/Home/");
+		if (debug) error("[APPLE] Discovered modern JRE: '%s'", result->buffer);
+		set_java_home(result->buffer);
+		string_release(base);
+		return 1;
+	}
+
+	string_set_length(base, 0);
+	string_append(base, "/System/Library/Java/JavaVirtualMachines");
+	if (sizeof(void *) > 4)
+		library_path = "Contents/Home/../Libraries/libserver.dylib";
+	else
+		library_path = "Contents/Home/../Libraries/libjvm.dylib";
+	find_newest(base, 1, library_path, result);
+	if (result->length) {
+		set_library_path(library_path + strlen("Contents/Home/"));
+		string_append(result, "/Contents/Home/");
+		if (debug) {
+			error("[APPLE] Discovered JavaVM framework: '%s'", result->buffer);
+		}
+		set_java_home(result->buffer);
+		string_release(base);
+		return 1;
+	}
+
+	string_release(base);
+	fprintf(stderr, "Warning: could not find Java bundle\n");
+	return 3;
 	}
 
 	/* Get a path for the JavaVM bundle. */

--- a/src/main/c/platform.c
+++ b/src/main/c/platform.c
@@ -431,7 +431,7 @@ int set_path_to_apple_JVM(void)
 	}
 	else {
 	struct string *base = string_init(32);
-	struct string *result = string_init(32);
+	struct string *jvm = string_init(32);
 	const char *library_path;
 
 	if (debug) error("[APPLE] No com.apple.JavaVM bundle found");
@@ -442,12 +442,12 @@ int set_path_to_apple_JVM(void)
 	string_set_length(base, 0);
 	string_append(base, ij_path("java/macosx"));
 	library_path = "jre/Contents/Home/lib/server/libjvm.dylib";
-	find_newest(base, 1, library_path, result);
-	if (result->length) {
+	find_newest(base, 1, library_path, jvm);
+	if (jvm->length) {
 		set_library_path(library_path + strlen("jre/Contents/Home/"));
-		string_append(result, "/jre/Contents/Home/");
-		if (debug) error("[APPLE] Discovered bundled JRE: '%s'", result->buffer);
-		set_java_home(result->buffer);
+		string_append(jvm, "/jre/Contents/Home/");
+		if (debug) error("[APPLE] Discovered bundled JRE: '%s'", jvm->buffer);
+		set_java_home(jvm->buffer);
 		string_release(base);
 		return 1;
 	}
@@ -455,12 +455,12 @@ int set_path_to_apple_JVM(void)
 	string_set_length(base, 0);
 	string_append(base, "/Library/Java/JavaVirtualMachines");
 	library_path = "Contents/Home/jre/lib/server/libjvm.dylib";
-	find_newest(base, 1, library_path, result);
-	if (result->length) {
+	find_newest(base, 1, library_path, jvm);
+	if (jvm->length) {
 		set_library_path(library_path + strlen("Contents/Home/jre/"));
-		string_append(result, "/Contents/Home/");
-		if (debug) error("[APPLE] Discovered modern JDK: '%s'", result->buffer);
-		set_java_home(result->buffer);
+		string_append(jvm, "/Contents/Home/");
+		if (debug) error("[APPLE] Discovered modern JDK: '%s'", jvm->buffer);
+		set_java_home(jvm->buffer);
 		string_release(base);
 		return 1;
 	}
@@ -468,12 +468,12 @@ int set_path_to_apple_JVM(void)
 	string_set_length(base, 0);
 	string_append(base, "/Library/Internet Plug-Ins/JavaAppletPlugin.plugin");
 	library_path = "Contents/Home/lib/server/libjvm.dylib";
-	find_newest(base, 1, library_path, result);
-	if (result->length) {
+	find_newest(base, 1, library_path, jvm);
+	if (jvm->length) {
 		set_library_path(library_path + strlen("Contents/Home/"));
-		string_append(result, "/Contents/Home/");
-		if (debug) error("[APPLE] Discovered modern JRE: '%s'", result->buffer);
-		set_java_home(result->buffer);
+		string_append(jvm, "/Contents/Home/");
+		if (debug) error("[APPLE] Discovered modern JRE: '%s'", jvm->buffer);
+		set_java_home(jvm->buffer);
 		string_release(base);
 		return 1;
 	}
@@ -484,14 +484,14 @@ int set_path_to_apple_JVM(void)
 		library_path = "Contents/Home/../Libraries/libserver.dylib";
 	else
 		library_path = "Contents/Home/../Libraries/libjvm.dylib";
-	find_newest(base, 1, library_path, result);
-	if (result->length) {
+	find_newest(base, 1, library_path, jvm);
+	if (jvm->length) {
 		set_library_path(library_path + strlen("Contents/Home/"));
-		string_append(result, "/Contents/Home/");
+		string_append(jvm, "/Contents/Home/");
 		if (debug) {
-			error("[APPLE] Discovered JavaVM framework: '%s'", result->buffer);
+			error("[APPLE] Discovered JavaVM framework: '%s'", jvm->buffer);
 		}
-		set_java_home(result->buffer);
+		set_java_home(jvm->buffer);
 		string_release(base);
 		return 1;
 	}

--- a/src/main/c/platform.c
+++ b/src/main/c/platform.c
@@ -140,11 +140,41 @@ static int MAYBE_UNUSED is_dylib(const char *path)
 	}
 
 	close(in);
+
+	/*
+	 * mach-o header parsing
+	 *
+	 * check cafebabe and feedface
+	 */
 	if (buffer[0] == 0xca && buffer[1] == 0xfe && buffer[2] == 0xba &&
 			buffer[3] == 0xbe && buffer[4] == 0x00 &&
 			buffer[5] == 0x00 && buffer[6] == 0x00 &&
 			(buffer[7] >= 1 && buffer[7] < 20))
 		return 32 | 64; /* might be a fat one, containing both */
+
+	/*
+	 * check both endians for feedface
+	 */
+	if ((buffer[0] == 0xcf &&
+			buffer[1] == 0xfa &&
+			buffer[2] == 0xed &&
+			buffer[3] == 0xfe) ||
+			(buffer[0] == 0xfe &&
+			buffer[1] == 0xed &&
+			buffer[2] == 0xfa &&
+			buffer[3] == 0xcf))
+		return 64;
+
+	if ((buffer[0] == 0xce &&
+			buffer[1] == 0xfa &&
+			buffer[2] == 0xed &&
+			buffer[3] == 0xfe) ||
+			(buffer[0] == 0xfe &&
+			buffer[1] == 0xed &&
+			buffer[2] == 0xfa &&
+			buffer[3] == 0xce))
+		return 32;
+
 	return 0;
 }
 

--- a/src/main/c/splash.c
+++ b/src/main/c/splash.c
@@ -39,7 +39,6 @@
 
 static int no_splash;
 static void (*SplashClose)(void);
-extern int debug;
 
 void disable_splash(void)
 {

--- a/src/main/include/common.h
+++ b/src/main/include/common.h
@@ -80,6 +80,14 @@ extern void win_verror(const char *fmt, va_list ap);
 #define PATH_MAX 1024
 #endif
 
+/* Global functions */
+extern int start_ij(void);
+
+/* Global variables */
+extern int debug;
+extern int info;
+extern int retrotranslator;
+
 static inline int prefixcmp(const char *string, const char *prefix)
 {
 	return strncmp(string, prefix, strlen(prefix));


### PR DESCRIPTION
Mac-specific Java detection now supports a bundled Java (in ImageJ.app/java).

Updates the dylib detection to properly match Java 8 binaries.

Closes #35 