### PR TITLE
Decrease WIN32 max heap size to 1224m

### DIFF
--- a/src/main/c/ImageJ.c
+++ b/src/main/c/ImageJ.c
@@ -1191,7 +1191,7 @@ static void jvm_workarounds(struct options *options)
 
 /* the maximal size of the heap on 32-bit systems, in megabyte */
 #ifdef WIN32
-#define MAX_32BIT_HEAP 1638
+#define MAX_32BIT_HEAP 1224
 #else
 #define MAX_32BIT_HEAP 1920
 #endif


### PR DESCRIPTION
I have tested for the maximum heap size on two different machines: A Windows 10 (32-bit) VM still works with 1408m, while the launcher crashes on a Windows 10 (32-bit) physical machine. On the latter machine, I have determined the max heap size to be 1224m. This launcher also works properly on the former VM and should do so on other machines for which the launcher has worked before.

**NB:** If you ever have to compile the launcher on Windows 10 (32-bit) with a current version of MinGW, remove [platform.c:L1072-1075](https://github.com/imagej/imagej-launcher/blob/master/src/main/c/platform.c#L1072-1075). There is a collision with the definition of `sleep()` in the `unistd.h` that is shipped with MinGW. I did not further investigate the issue since the aforementioned hack worked for me without any observable issues.