### PR TITLE
ImageJ.c: properly handle --showUI argument

### DIFF
--- a/src/main/c/ImageJ.c
+++ b/src/main/c/ImageJ.c
@@ -1380,6 +1380,8 @@ static int handle_one_option2(int *i, int argc, const char **argv)
 		allow_multiple = 1;
 	else if (handle_one_option(i, argv, "--plugins", &arg))
 		string_addf(&plugin_path, "-Dplugins.dir=%s", arg.buffer);
+	else if (!strcmp(argv[*i], "--showUI"))
+		add_option(&options, "--showUI", 1);
 	else if (handle_one_option(i, argv, "--run", &arg)) {
 		/* pass unparsed to ImageJ2 */
 		if (!legacy_mode) {


### PR DESCRIPTION
The idea of `--showUI` is to have subsequent arguments (like `--run`) executed after a UI is available. This commit adds handling of `--showUI` such that the order of arguments is preserved when passed to the JVM.

This PR is required to support the desired use of  `--showUI` as introduced by https://github.com/scijava/scijava-common/pull/257.