### PR TITLE
Fix MINGW64 builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>12.0.0</version>
+		<version>17.1.1</version>
 		<relativePath />
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,7 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 		<ij.executable.name />
 		<nar.arch.path />
 		<java.os.include />
+		<int64.flag />
 		<libdl.name>dl</libdl.name>
 		<skipTests>true</skipTests>
 		<stack.protector.option />
@@ -177,6 +178,7 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 							<option>${stack.protector.option}</option>
 							<option>${architecture.option}</option>
 							<option>${subsystem.option}</option>
+							<option>${int64.flag}</option>
 							<option>${debug.option}</option>
 						</options>
 					</c>
@@ -365,6 +367,7 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 				<libdl.name>kernel32</libdl.name>
 				<ij.executable.name>ImageJ-win64.exe</ij.executable.name>
 				<nar.arch.path>amd64</nar.arch.path>
+				<int64.flag>-D__int64=int64_t</int64.flag>
 			</properties>
 		</profile>
 

--- a/src/main/c/platform.c
+++ b/src/main/c/platform.c
@@ -1069,10 +1069,15 @@ void *dlsym(void *handle, const char *name)
 	return result;
 }
 
+#ifndef __MINGW32__
+/* __MINGW32__ is defined by MinGW64 for both x86 and amd64:
+ * http://mingw.5.n7.nabble.com/Macros-MINGW32-AND-MINGW64-tp26319p26320.html
+*/
 void sleep(int seconds)
 {
 	Sleep(seconds * 1000);
 }
+#endif
 
 /*
  * There is no setenv on Windows, so it should be safe for us to

--- a/src/main/include/platform.h
+++ b/src/main/include/platform.h
@@ -85,7 +85,12 @@ extern void *dlopen(const char *name, int flags);
 extern char *dlerror(void);
 extern void *dlsym(void *handle, const char *name);
 
+#ifndef __MINGW32__
+/* __MINGW32__ is defined by MinGW64 for both x86 and amd64:
+ * http://mingw.5.n7.nabble.com/Macros-MINGW32-AND-MINGW64-tp26319p26320.html
+*/
 extern void sleep(int seconds);
+#endif
 
 /*
  * There is no setenv on Windows, so it should be safe for us to


### PR DESCRIPTION
This PR introduces two fixes to get builds with MINGW64 running:

- Since a POSIX compatible `sleep()` is provided by MinGW64's `unistd.h`, the declaration and definition is disabled for this build system (keeps backward compatibility)
- Introduces a flag that is required to work around an issue with JVM header files (i.e. `jni_md.h` uses `__int64` which is not set on MINGW64 per default)