### PR TITLE
Update paths for Java 9

### DIFF
--- a/src/main/c/ImageJ.c
+++ b/src/main/c/ImageJ.c
@@ -1137,43 +1137,6 @@ static const char *skip_whitespace(const char *string)
 	return string;
 }
 
-static const char *parse_number(const char *string, unsigned int *result, int shift)
-{
-	char *endp;
-	long value = strtol(string, &endp, 10);
-
-	if (string == endp)
-		return NULL;
-
-	*result |= (int)(value << shift);
-	return endp;
-}
-
-static unsigned int guess_java_version(void)
-{
-	const char *java_home = get_jre_home();
-
-	while (java_home && *java_home) {
-		if (!prefixcmp(java_home, "jdk") || !prefixcmp(java_home, "jre")) {
-			unsigned int result = 0;
-			const char *p = java_home + 3;
-
-			p = parse_number(p, &result, 24);
-			if (p && *p == '.')
-				p = parse_number(p + 1, &result, 16);
-			if (p && *p == '.')
-				p = parse_number(p + 1, &result, 8);
-			if (p) {
-				if (*p == '_')
-					p = parse_number(p + 1, &result, 0);
-				return result;
-			}
-		}
-		java_home += strcspn(java_home, "\\/") + 1;
-	}
-	return 0;
-}
-
 static void jvm_workarounds(struct options *options)
 {
 	unsigned int java_version = guess_java_version();
@@ -2344,6 +2307,10 @@ static void adjust_java_home_if_necessary(void)
 
 	set_default_library_path();
 	set_library_path(get_default_library_path());
+
+	char* debugPath = get_library_path();
+	if (debug)
+		error("Default library path (relative): %s", debugPath);
 
 	buffer = string_copy(ij_path("java"));
 	ij_dir_len = buffer->length - 4;

--- a/src/main/c/splash.c
+++ b/src/main/c/splash.c
@@ -62,7 +62,7 @@ struct string *get_splashscreen_lib_path(const char *jre_home)
 #if defined(WIN32)
 	return string_initf("%s/bin/splashscreen.dll", jre_home);
 #elif defined(__linux__)
-	return string_initf("%s/lib/%s/libsplashscreen.so", jre_home, sizeof(void *) == 8 ? "amd64" : "i386");
+	return string_initf("%s/lib/%slibsplashscreen.so", jre_home, sizeof(void *) == 8 ? (guess_java_version() >= 0x09000000 ? "" : "amd64/") : "i386/");
 #else
 	return NULL;
 #endif

--- a/src/main/include/java.h
+++ b/src/main/include/java.h
@@ -31,6 +31,8 @@
 #ifndef JAVA_H
 #define JAVA_H
 
+extern unsigned int guess_java_version(void);
+
 extern const char *get_java_command(void);
 
 extern void set_java_home(const char *absolute_path);


### PR DESCRIPTION
Since Oracle has decided to get rid of 32-bit builds for most OSs, they have removed OS-dependent folders in JRE/JDK folder structures. To keep compatibility, move `guess_java_version()` to `java.c` and get rid of circular usage when trying to identify JRE/JDKs.

Closes #51.