### PR TITLE
Fix detection of bundled JDK

### DIFF
--- a/src/main/c/ImageJ.c
+++ b/src/main/c/ImageJ.c
@@ -2311,7 +2311,7 @@ static void adjust_java_home_if_necessary(void)
 	// HACK: We are looking for a bundled JDK first
 	set_library_path(
 #if defined(__APPLE__)
-		"lib/server/libjvm.dylib"
+		"Contents/Home/lib/server/libjvm.dylib"
 #elif defined(WIN32)
 		sizeof(void *) < 8 ? "bin/client/jvm.dll" : "bin/server/jvm.dll"
 #else

--- a/src/main/c/ImageJ.c
+++ b/src/main/c/ImageJ.c
@@ -2294,6 +2294,9 @@ int start_ij(void)
 /* TODO: try to find Java even if there is JRE local to ImageJ */
 static void adjust_java_home_if_necessary(void)
 {
+	if (debug)
+		error("Entering adjust_java_home_if_necessary.");
+
 	struct string *result, *buffer, *path;
 	const char *prefix = "jre/";
 	int depth = 2, ij_dir_len;

--- a/src/main/c/file-funcs.c
+++ b/src/main/c/file-funcs.c
@@ -487,6 +487,9 @@ void read_file_as_string(const char *file_name, struct string *contents)
 	fclose(in);
 }
 
+/*
+ * Traverses subfolders of a path up to a defined depth to find a file.
+ */
 void find_newest(struct string *path, int max_depth, const char *file, struct string *result)
 {
 	int len = path->length;

--- a/src/main/c/java.c
+++ b/src/main/c/java.c
@@ -43,7 +43,7 @@ static const char *relative_java_home;
 static const char *library_path;
 static const char *default_library_path;
 #if defined(__APPLE__)
-static const char *default_library_paths[1] = {"lib/server/libjvm.dylib"};
+static const char *default_library_paths[1] = {"Contents/Home/lib/server/libjvm.dylib"};
 #elif defined(WIN32)
 static const char *default_library_paths[2] = {"bin/client/jvm.dll", "bin/server/jvm.dll"};
 #else
@@ -433,7 +433,7 @@ void set_default_library_path(void)
 {
 	default_library_path =
 #if defined(__APPLE__)
-		"lib/server/libjvm.dylib";
+		"Contents/Home/lib/server/libjvm.dylib";
 #elif defined(WIN32)
 		sizeof(void *) < 8 ? "bin/client/jvm.dll" : "bin/server/jvm.dll";
 #else

--- a/src/main/c/java.c
+++ b/src/main/c/java.c
@@ -75,6 +75,7 @@ static const char *parse_number(const char *string, unsigned int *result, int sh
 
 unsigned int guess_java_version(void)
 {
+	error("guess_java_version: Entering");
 	const char *java_home = get_jre_home();
 
 	while (java_home && *java_home) {
@@ -95,11 +96,13 @@ unsigned int guess_java_version(void)
 			if (p) {
 				if (*p == '_')
 					p = parse_number(p + 1, &result, 0);
+				error("guess_java_version: Returning %d", result);
 				return result;
 			}
 		}
 		java_home += strcspn(java_home, "\\/") + 1;
 	}
+	error("guess_java_version: Returning 0");
 	return 0;
 }
 
@@ -137,16 +140,21 @@ unsigned int guess_java_version_for_path(const char *java_home)
 
 void set_java_home(const char *absolute_path)
 {
+	error("set_java_home: Entering with %s", absolute_path);
 	absolute_java_home = absolute_path;
+	error("set_java_home: absolute_java_home is now: %s", absolute_java_home);
 }
 
 void set_relative_java_home(const char *relative_path)
 {
+	error("set_relative_java_home: Entering with %s", relative_path);
 	relative_java_home = relative_path;
+	error("set_relative_java_home: relative_java_home is now: %s", relative_java_home);
 }
 
 int is_jre_home(const char *directory)
 {
+	error("is_jre_home: Entering with %s", directory);
 	int i;
 	int result = 0;
 	if (dir_exists(directory)) {
@@ -172,8 +180,13 @@ int is_jre_home(const char *directory)
 	return result;
 }
 
+/**
+ * Checks if a directory is a java home directory by calling is_jre_home
+ * on <directory>/jre and <directory>.
+ */
 int is_java_home(const char *directory)
 {
+	error("is_java_home: Entering with %s", directory);
 	struct string *jre = string_initf("%s/jre", directory);
 	int result = is_jre_home(jre->buffer);
 	if (!result) {
@@ -187,7 +200,9 @@ int is_java_home(const char *directory)
 
 const char *get_java_home_env(void)
 {
+	error("get_java_home_env: Entering");
 	const char *env = getenv("JAVA_HOME");
+	error("get_java_home_env: JAVA_HOME is set to %s", env);
 	if (env && is_java_home(env))
 		return env;
 	return NULL;
@@ -195,6 +210,7 @@ const char *get_java_home_env(void)
 
 const char *get_java_home(void)
 {
+	error("get_java_home: Entering");
 	const char *result;
 
 	/* Check if an absolute path has been previously set */
@@ -205,36 +221,51 @@ const char *get_java_home(void)
 
 	/* Check if a relative path has been previously set */
 	result = !relative_java_home ? NULL : ij_path(relative_java_home);
-	if (result && is_java_home(result))
+	error("get_java_home: Trying to use relative_java_home: %s", result);
+	if (result && is_java_home(result)) {
+		error("get_java_home: Returning %s", result);
 		return result;
+	}
 	if (result && (!suffixcmp(result, -1, "/jre") ||
 			 !suffixcmp(result, -1, "/jre/")) &&
 			is_jre_home(result)) {
 		/* Strip jre/ from result */
 		char *new_eol = (char *)(result + strlen(result) - 4);
 		*new_eol = '\0';
+		error("get_java_home: Returning %s", result);
 		return result;
 	}
 
 	/* Check JAVA_HOME environment variable */
 	result = get_java_home_env();
-	if (result)
+	if (result) {
+		error("get_java_home: Returning %s", result);
 		return result;
+	}
+
+	/* Otherwise use the system's Java */
+	error("get_java_home: Returning discover_system_java_home()");
 	return discover_system_java_home();
 }
 
+/* Returns the JRE/JAVA HOME folder that will be used */
 const char *get_jre_home(void)
 {
+	error("get_jre_home: Entering");
 	const char *result;
 	int len;
 	static struct string *jre;
 	static int initialized;
 
-	if (jre)
+	if (jre) {
+		error("get_jre_home: Returning %s", jre->buffer);
 		return jre->buffer;
+	}	
 
-	if (initialized)
+	if (initialized) {
+		error("get_jre_home: Returning NULL");
 		return NULL;
+	}	
 	initialized = 1;
 
 	/* ImageJ 1.x ships the JRE in <ij.dir>/jre/ */
@@ -270,6 +301,7 @@ const char *get_jre_home(void)
 		const char *jre_home = getenv("JRE_HOME");
 		if (jre_home && *jre_home && is_jre_home(jre_home)) {
 			jre = string_copy(jre_home);
+			error("get_jre_home: Setting jre to %s", jre->buffer);
 			if (debug)
 				error("Found a JRE in JRE_HOME: %s", jre->buffer);
 			return jre->buffer;
@@ -277,6 +309,7 @@ const char *get_jre_home(void)
 		jre_home = getenv("JAVA_HOME");
 		if (jre_home && *jre_home && is_jre_home(jre_home)) {
 			jre = string_copy(jre_home);
+			error("get_jre_home: Setting jre to %s", jre->buffer);
 			if (debug)
 				error("Found a JRE in JAVA_HOME: %s", jre->buffer);
 			return jre->buffer;
@@ -289,18 +322,21 @@ const char *get_jre_home(void)
 	len = strlen(result);
 	if (len > 4 && !suffixcmp(result, len, "/jre")) {
 		jre = string_copy(result);
+		error("get_jre_home: Setting jre to %s", jre->buffer);
 		if (debug)
 			error("JAVA_HOME points to a JRE: '%s'", result);
 		return jre->buffer;
 	}
 
 	jre = string_initf("%s/jre", result);
+	error("get_jre_home: Setting jre to %s", jre->buffer);
 	if (dir_exists(jre->buffer)) {
 		if (debug)
 			error("JAVA_HOME contains a JRE: '%s'", jre->buffer);
 		return jre->buffer;
 	}
 	string_set(jre, result);
+	error("get_jre_home: Setting jre to %s", jre->buffer);
 	if (debug)
 		error("JAVA_HOME appears to be a JRE: '%s'", jre->buffer);
 	return jre->buffer;
@@ -308,6 +344,7 @@ const char *get_jre_home(void)
 
 char *discover_system_java_home(void)
 {
+	error("discover_system_java_home: Entering");
 #ifdef WIN32
 	HKEY key;
 	HRESULT result;
@@ -359,6 +396,7 @@ char *discover_system_java_home(void)
 		 */
 		if (debug)
 			error("Ignoring Apple Framework java executable: '%s'", java_executable);
+		error("discover_system_java_home: Returning NULL");
 		return NULL;
 	}
 #endif
@@ -374,8 +412,10 @@ char *discover_system_java_home(void)
 				len -= strlen(suffixes[i]);
 				path[len] = '\0';
 			}
+		error("discover_system_java_home: Returning %s", path);
 		return path;
 	}
+	error("discover_system_java_home: Returning NULL");
 	return NULL;
 #endif
 }
@@ -408,7 +448,9 @@ const char *get_default_library_path(void)
 
 void set_library_path(const char *path)
 {
+	error("set_library_path: Entering with %s", path);
 	library_path = path;
+	error("library_path is now %s", library_path);
 }
 
 const char *get_library_path(void)

--- a/src/main/c/platform.c
+++ b/src/main/c/platform.c
@@ -400,6 +400,8 @@ release_buffer:
 
 int set_path_to_apple_JVM(void)
 {
+	error("set_path_to_apple_JVM: Entering");
+
 	/*
 	 * MacOSX specific stuff for system java
 	 * -------------------------------------

--- a/src/main/include/java.h
+++ b/src/main/include/java.h
@@ -32,6 +32,7 @@
 #define JAVA_H
 
 extern unsigned int guess_java_version(void);
+extern unsigned int guess_java_version_for_path(const char *java_home);
 
 extern const char *get_java_command(void);
 


### PR DESCRIPTION
Since changing the logic for determining if a folder is a proper JDK/JRE in order to support Java9+, a system Java9+ would always take precedence over the bundled Java8 one. This PR fixes this behavior and adds an extremely inelegant hack to also make this work on macOS.