### PR TITLE
Support multiple splash icons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,8 +136,6 @@ Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
 Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 		<license.projectName>ImageJ software for multidimensional image processing and analysis.</license.projectName>
 
-		<scijava.jvm.version>1.6</scijava.jvm.version>
-
 		<target.architecture />
 		<debug.option />
 		<skipTests>true</skipTests>
@@ -153,7 +151,6 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>scijava-common</artifactId>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/net/imagej/launcher/ClassLauncher.java
+++ b/src/main/java/net/imagej/launcher/ClassLauncher.java
@@ -80,10 +80,23 @@ public class ClassLauncher {
 		// property.
 		if (Boolean.getBoolean("imagej.splash")) {
 			try {
-				SplashScreen.show();
-			}
-			catch (Throwable t) {
-				t.printStackTrace();
+				URLClassLoader classLoader = ClassLoaderPlus.getInImageJDirectory(null, "jars/imagej-launcher.jar");
+				classLoader = ClassLoaderPlus.getInImageJDirectory(classLoader, "jars/scijava-common.jar");
+				try {
+					// Invoke SplashScreen.show() with the previously
+					// constructed class loader
+					Class<?> splashScreen = classLoader.loadClass("net.imagej.launcher.SplashScreen");
+					Method method = splashScreen.getMethod("show");
+					method.invoke(null);
+				} catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException e) {
+					if (debug)
+						e.printStackTrace();
+				} catch (final InvocationTargetException e) {
+					if (debug)
+						e.getTargetException().printStackTrace();
+				}
+			} catch (Throwable e) {
+				e.printStackTrace();
 			}
 		}
 		run(arguments);

--- a/src/main/java/net/imagej/launcher/ClassLauncher.java
+++ b/src/main/java/net/imagej/launcher/ClassLauncher.java
@@ -74,37 +74,6 @@ public class ClassLauncher {
 	 */
 	public static void main(final String[] arguments) {
 		originalArguments = arguments;
-		// If the imagej.splash system property is not set, the splash screen is not
-		// shown. The --dry-run option of the launcher will set this property to
-		// true by default. Starting the launcher with --no-splash does not set the
-		// property.
-		if (Boolean.getBoolean("imagej.splash")) {
-			try {
-				URLClassLoader classLoader = ClassLoaderPlus.getInImageJDirectory(null, "jars/imagej-launcher.jar");
-				classLoader = ClassLoaderPlus.getInImageJDirectory(classLoader, "jars/scijava-common.jar");
-				try {
-					// Invoke SplashScreen.show() with the previously
-					// constructed class loader
-					Class<?> splashScreen = classLoader.loadClass("net.imagej.launcher.SplashScreen");
-					Method method = splashScreen.getMethod("show");
-					method.invoke(null);
-				} catch (final ClassNotFoundException e) {
-					if (debug)
-						e.printStackTrace();
-				} catch (final NoSuchMethodException e) {
-					if (debug)
-						e.printStackTrace();
-				} catch (final IllegalAccessException e) {
-					if (debug)
-						e.printStackTrace();
-				} catch (final InvocationTargetException e) {
-					if (debug)
-						e.getTargetException().printStackTrace();
-				}
-			} catch (Throwable e) {
-				e.printStackTrace();
-			}
-		}
 		run(arguments);
 	}
 
@@ -166,6 +135,32 @@ public class ClassLauncher {
 			else {
 				System.err.println("Unknown option: " + option + "!");
 				System.exit(1);
+			}
+		}
+
+		// If the imagej.splash system property is not set, the splash screen is
+		// not shown. The --dry-run option of the launcher will set this
+		// property to true by default. Starting the launcher with --no-splash
+		// does not set the property.
+		if (Boolean.getBoolean("imagej.splash")) {
+			try {
+				// Invoke SplashScreen.show() with the previously
+				// constructed class loader
+				Class<?> splashScreen = classLoader.loadClass("net.imagej.launcher.SplashScreen");
+				Method method = splashScreen.getMethod("show");
+				method.invoke(null);
+			} catch (final ClassNotFoundException e) {
+				if (debug)
+					e.printStackTrace();
+			} catch (final NoSuchMethodException e) {
+				if (debug)
+					e.printStackTrace();
+			} catch (final IllegalAccessException e) {
+				if (debug)
+					e.printStackTrace();
+			} catch (final InvocationTargetException e) {
+				if (debug)
+					e.getTargetException().printStackTrace();
 			}
 		}
 

--- a/src/main/java/net/imagej/launcher/ClassLauncher.java
+++ b/src/main/java/net/imagej/launcher/ClassLauncher.java
@@ -88,7 +88,13 @@ public class ClassLauncher {
 					Class<?> splashScreen = classLoader.loadClass("net.imagej.launcher.SplashScreen");
 					Method method = splashScreen.getMethod("show");
 					method.invoke(null);
-				} catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException e) {
+				} catch (final ClassNotFoundException e) {
+					if (debug)
+						e.printStackTrace();
+				} catch (final NoSuchMethodException e) {
+					if (debug)
+						e.printStackTrace();
+				} catch (final IllegalAccessException e) {
 					if (debug)
 						e.printStackTrace();
 				} catch (final InvocationTargetException e) {

--- a/src/main/java/net/imagej/launcher/SplashIcon.java
+++ b/src/main/java/net/imagej/launcher/SplashIcon.java
@@ -1,0 +1,98 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2007 - 2018 ImageJ developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.launcher;
+
+import java.awt.Component;
+import java.awt.Graphics;
+import java.net.URL;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.swing.ImageIcon;
+
+/**
+ * A custom ImageIcon implementation that renders various splash screens onto a
+ * main icon.
+ *
+ * @author Stefan Helfrich
+ */
+public class SplashIcon extends ImageIcon {
+
+	private static final long serialVersionUID = 1L;
+	private final List<ImageIcon> splashs = new LinkedList<>();
+	private static final int ICON_HEIGHT = 24;
+	private static final int ICON_WIDTH = 24;
+	private static final int GAP_WIDTH = 2;
+
+	public SplashIcon(final URL main, final Collection<URL> splashs) {
+		super(main);
+
+		// FIXME Simplify with streams when support for Java 6 was dropped
+		for (URL url : splashs) {
+			if (url == null) {
+				continue;
+			}
+			this.splashs.add(new ImageIcon(url));
+		}
+	}
+
+	@Override
+	public void paintIcon(Component c, Graphics g, int x, int y) {
+		// Paint the main icon to show in the background
+		super.paintIcon(c, g, x, y);
+
+		// Get size of main icon
+		int mainWidth = super.getIconWidth();
+		int mainHeight = super.getIconHeight();
+
+		// Compute maximum number of splash icons that fit into one row
+		final int maxNumberOfIcons = (int) Math.floor(mainWidth / (ICON_WIDTH + GAP_WIDTH));
+
+		// Compute number of painted icons
+		final int numberOfIcons = maxNumberOfIcons < splashs.size() ? maxNumberOfIcons : splashs.size();
+
+		// Compute offset for centering icons
+		final int remainder = mainWidth - numberOfIcons * ICON_WIDTH - (numberOfIcons - 1) * GAP_WIDTH;
+		final int offset = (int) Math.floor(remainder / 2);
+
+		for (int i = 0; i < numberOfIcons; i++) {
+			final ImageIcon imageIcon = splashs.get(i);
+			if (imageIcon == null) {
+				continue;
+			}
+
+			// Use index to determine the position
+			g.drawImage(imageIcon.getImage(), offset + i * (ICON_WIDTH + GAP_WIDTH), mainHeight - ICON_HEIGHT,
+					offset + i * (ICON_WIDTH + GAP_WIDTH) + ICON_WIDTH, mainHeight, 0, 0, imageIcon.getIconWidth(),
+					imageIcon.getIconHeight(), c);
+		}
+	}
+}

--- a/src/main/java/net/imagej/launcher/SplashIcon.java
+++ b/src/main/java/net/imagej/launcher/SplashIcon.java
@@ -47,7 +47,7 @@ import javax.swing.ImageIcon;
 public class SplashIcon extends ImageIcon {
 
 	private static final long serialVersionUID = 1L;
-	private final List<ImageIcon> splashs = new LinkedList<>();
+	private final List<ImageIcon> splashs = new LinkedList<ImageIcon>();
 	private static final int ICON_HEIGHT = 24;
 	private static final int ICON_WIDTH = 24;
 	private static final int GAP_WIDTH = 2;

--- a/src/main/java/net/imagej/launcher/SplashScreen.java
+++ b/src/main/java/net/imagej/launcher/SplashScreen.java
@@ -129,4 +129,8 @@ public class SplashScreen {
 		((Window) splashWindow).dispose();
 		splashWindow = null;
 	}
+
+	public static void main(String[] args) {
+		SplashScreen.show();
+	}
 }

--- a/src/main/java/net/imagej/launcher/SplashScreen.java
+++ b/src/main/java/net/imagej/launcher/SplashScreen.java
@@ -33,13 +33,17 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Window;
 import java.io.File;
+import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Map;
 
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JProgressBar;
 import javax.swing.JWindow;
+
+import org.scijava.util.FileUtils;
 
 /**
  * Application splash screen.
@@ -50,7 +54,8 @@ public class SplashScreen {
 
 	private static final int PROGRESS_MAX = 10000;
 
-	private static final String LOGO_PATH = "splash/imagej.png";
+	private static final String LOGO_FILENAME = "imagej.png";
+	private static final String LOGO_PATH = "splash/" + LOGO_FILENAME;
 
 	private static Object splashWindow;
 	private static Object progressBar;
@@ -59,10 +64,12 @@ public class SplashScreen {
 		if (Boolean.getBoolean("java.awt.headless")) return;
 		final JWindow window = new JWindow();
 		splashWindow = window; // Save a non-AWT reference to the window.
+
+		// Get splash icon from current class loader
 		final ClassLoader classLoader = //
 			Thread.currentThread().getContextClassLoader();
-		final URL logoURL = classLoader.getResource(LOGO_PATH);
-		final ImageIcon imageIcon;
+		URL logoURL = classLoader.getResource(LOGO_PATH);
+
 		if (logoURL == null) {
 			// Look for images/icon.png on disk, as a fallback.
 			// For backwards compatibility with old Fiji installations.
@@ -70,9 +77,19 @@ public class SplashScreen {
 				System.getProperty("imagej.dir") : ".";
 			final File logoFile = new File(parent, "images/icon.png");
 			if (!logoFile.exists()) return;
-			imageIcon = new ImageIcon(logoFile.getPath());
+			try {
+				logoURL = logoFile.toURI().toURL();
+			} catch (MalformedURLException e) {
+				e.printStackTrace();
+				return;
+			}
 		}
-		else imageIcon = new ImageIcon(logoURL);
+
+		// Find all splash icons on the classpath
+		Map<String, URL> splashs = FileUtils.findResources(".*", "splash", null);
+		splashs.remove(LOGO_FILENAME); // We are using this as the main logo already
+
+		final ImageIcon imageIcon = new SplashIcon(logoURL, splashs.values());
 		final JLabel logoImage = new JLabel(imageIcon);
 		final JProgressBar bar = new JProgressBar();
 		bar.setMaximum(PROGRESS_MAX);


### PR DESCRIPTION
This PR adds functionality to the Java-based splash screen to paint multiple small splash icons on the main logo.

![Uploading Screen Shot 2019-01-17 at 7.42.21 AM.png…]()

Icons ideally are PNGs with transparent background and need to be located within `src/main/resources/splash` in a project. They will be picked up by the splash once the JAR file of the project is installed in ImageJ/Fiji e.g. via the updater.