### PR TITLE
Add call to XInitThreads on Linux before any GUI is constructed

### DIFF
--- a/src/main/c/ImageJ.c
+++ b/src/main/c/ImageJ.c
@@ -2433,16 +2433,17 @@ int main(int argc, char **argv, char **e)
 	if (!headless) {
 		void *libX11Handle = dlopen("libX11.so", RTLD_LAZY);
 		if(libX11Handle != NULL) {
-			printf("Running XInitThreads\n");
+			if (debug)
+				error("Running XInitThreads\n");
 			xinit_threads_reference = dlsym(libX11Handle, "XInitThreads");
 
 			if(xinit_threads_reference != NULL) {
 				xinit_threads_reference();
 			} else {
-				fprintf(stderr, "Could not find XInitThreads in X11 library: %s\n", dlerror());
+				error("Could not find XInitThreads in X11 library: %s\n", dlerror());
 			}
 		} else {
-			fprintf(stderr, "Could not find X11 library, not running XInitThreads.\n");
+			error("Could not find X11 library, not running XInitThreads.\n");
 		}
 	}
 #endif


### PR DESCRIPTION
The call to XInitThreads is necessary to avoid issues with Xlib when running 3D graphics stuff via Vulkan inside ImageJ, as e.g. required by SciView. The call is done dynamically via `dlopen`/`dlsym` to avoid problems when running e.g. on headless machines or machines that do not have X11 installed. 

I have added the call for the moment to `main()`, I'm happy to move it if there's better locations for it. 