### PR TITLE
Consider files with an mtime of 0 as well

### DIFF
--- a/src/main/c/file-funcs.c
+++ b/src/main/c/file-funcs.c
@@ -399,7 +399,7 @@ char *find_jar(const char *jars_directory, const char *prefix)
 			continue;
 		string_set_length(buffer, length);
 		string_append(buffer, name);
-		if (!stat(buffer->buffer, &st) && st.st_mtime > mtime) {
+		if (!stat(buffer->buffer, &st) && st.st_mtime >= mtime) {
 			free(result);
 			result = strdup(buffer->buffer);
 			mtime = st.st_mtime;


### PR DESCRIPTION
Hi!
When creating a [Flatpak](https://flatpak.org/) bundle for Fiji, I stumbled upon this issue which was fairly hard to find even though it's quite simple.
Flatpak doesn't save mtimes, which trips up imagej-launcher and makes it refuse to launch anything.
Regardless of this quirk, if stat worked the file exists and we should consider it for launching, so checking for bigger-or-equal zero is the slightly more correct behavior.
Merging this helps the Flatpak Fiji PR at https://github.com/fiji/fiji-builds/pull/8, so we don't need to carry an extra patch.
It should also not cause any problems with existing installations.
Thanks for considering!